### PR TITLE
fix option handling in Makefile.PL when libgd-dev is not installed

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,15 @@ my $AUTOCONFIG = 0;      # global set by try_to_autoconfigure() below
 my ($options,$lib_gd_path,$lib_ft_path,$lib_png_path,$lib_jpeg_path,$lib_xpm_path,$lib_zlib_path,$force);
 
 use Getopt::Long;
-GetOptions("ignore_missing_gd" => \$force);
+my $result = GetOptions("options=s"         => \$options,
+			"lib_gd_path=s"     => \$lib_gd_path,
+			"lib_ft_path=s"     => \$lib_ft_path,
+			"lib_png_path=s"    => \$lib_png_path,
+			"lib_jpeg_path=s"   => \$lib_jpeg_path,
+			"lib_xpm_path=s"    => \$lib_xpm_path,
+			"lib_zlib_path=s"   => \$lib_zlib_path,
+			"ignore_missing_gd" => \$force,
+		       );
 
 unless (try_to_autoconfigure(\$options,\$lib_gd_path,\@INC,\@LIBPATH,\@LIBS) || $force) {
     die <<END;
@@ -47,14 +55,6 @@ if (-d '/usr/lib64') {
 #############################################################################################
 # Build options passed in to script to support reproducible builds via Makefiles
 #############################################################################################
-my $result = GetOptions("options=s"       => \$options,
-			"lib_gd_path=s"   => \$lib_gd_path,
-			"lib_ft_path=s"   => \$lib_ft_path,
-			"lib_png_path=s"  => \$lib_png_path,
-			"lib_jpeg_path=s" => \$lib_jpeg_path,
-			"lib_xpm_path=s"  => \$lib_xpm_path,
-			"lib_zlib_path=s" => \$lib_zlib_path,
-		       );
 unless ($result) {
   print STDERR <<END;
 Usage: perl Makefile.PL [options]


### PR DESCRIPTION
the call to GetOptions() must be unique.

before fix:

```
$ perl Makefile.PL -options=PNG,FT -ignore_missing_gd
Unknown option: options

Where is libgd installed? [/usr/lib]

Please choose the features that match how libgd was built:
Build JPEG support? [y]
Build PNG support? [y]
Build FreeType support? [y]
Build GIF support? [y]
Build support for animated GIFs? [y]
Build XPM support? [y]
```

with fix:

```
$ perl Makefile.PL -options=PNG,FT -ignore_missing_gd
Included Features:          PNG,FT

Where is libgd installed? [/usr/lib]
```
