### PR TITLE
Force

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,13 +35,15 @@ END
 }
 
 push @LIBS, "-lgd";
-@INC     = qw(-I/usr/include -I/usr/include/gd) unless @INC;
-@LIBPATH = qw(-L/usr/lib/X11 -L/usr/X11R6/lib -L/usr/X11/lib -L/usr/lib) unless @LIBPATH;
+unless ($force) {
+  @INC     = qw(-I/usr/include -I/usr/include/gd) unless @INC;
+  @LIBPATH = qw(-L/usr/lib/X11 -L/usr/X11R6/lib -L/usr/X11/lib -L/usr/lib) unless @LIBPATH;
 
-# support for AMD64 libraries
-if (-d '/usr/lib64') {
-  my @libs64 = map {my $a = $_; $a=~ s/lib$/lib64/; $a} @LIBPATH;
-  @LIBPATH = (@LIBPATH,@libs64);
+  # support for AMD64 libraries
+  if (-d '/usr/lib64') {
+    my @libs64 = map {my $a = $_; $a=~ s/lib$/lib64/; $a} @LIBPATH;
+    @LIBPATH = (@LIBPATH,@libs64);
+  }
 }
 
 #############################################################################################

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,9 +34,9 @@ If you want to try to compile anyway, please rerun this script with the option -
 END
 }
 
+push @LIBS, "-lgd";
 @INC     = qw(-I/usr/include -I/usr/include/gd) unless @INC;
 @LIBPATH = qw(-L/usr/lib/X11 -L/usr/X11R6/lib -L/usr/X11/lib -L/usr/lib) unless @LIBPATH;
-@LIBS    = qw(-lgd) unless @LIBS;
 
 # support for AMD64 libraries
 if (-d '/usr/lib64') {
@@ -291,7 +291,6 @@ sub try_to_autoconfigure {
   @$LIBPATH      = map {s/^-L// && "-L$_"} split /\s+/,$ldflags;
   @$LIBS         = split /\s+/,$libs;
 
-  push @$LIBS,"-lgd";
   push @$LIBPATH,"-L$libdir";
   ($$lib_gd_path = $libdir) =~ s!/[^/]+$!!;
   $$options      = $features;


### PR DESCRIPTION
I want to cross-compiling Perl-GD for an embedded Linux (see www.buildroot.net), so autoconfigure can not work for me.
I use the option `ignore_missing_gd` (and `lib_*_path`), when I call the C cross compiler, the include paths and lib paths must not contain any path of my host machine. So @INC and @LIBPATH must stay empty.

(see my current work at https://github.com/fperrad/br/tree/dancer2/dancer2/package/perl-gd)
