### PR TITLE
Updated detection to cope with gdlib-config retuning GD_GIFANIM not GD_ANIMGIF in GD library  2.1.1-dev@.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -157,7 +157,7 @@ if( defined($options) )
   $XPM       = $options =~ m/XPM/i;
   $GIF       = $options =~ m/GIF/i;
   $PNG       = $options =~ m/PNG/i;
-  $ANIMGIF   = $GIF && $options =~ m/ANIMGIF/i;
+  $ANIMGIF   = $GIF && ($options =~ m/ANIMGIF/i || $options =~ m/GIFANIM/i);
   $VERSION_33= $options =~ m/VERSION_33/i;
   $UNCLOSEDPOLY  = $options =~ m/UNCLOSEDPOLY/i;
   $FONTCONFIG  = $options =~ m/FONTCONFIG/i;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -299,8 +299,10 @@ sub try_to_autoconfigure {
   ($$lib_gd_path = $libdir) =~ s!/[^/]+$!!;
   $$options      = $features;
 
-  my ($minor)    = $version =~ /^2\.\d+\.(\d+)$/;
-  $$options     .= " GD_UNCLOSEDPOLY GD_ANIMGIF GD_FTCIRCLE VERSION_33" if defined($minor) && $minor >= 33;
+  my ($mid,$minor)    = $version =~ /^2\.(\d+)\.(\d+)/;
+  if( defined $mid && defined $minor ) {
+    $$options     .= " GD_UNCLOSEDPOLY GD_ANIMGIF GD_FTCIRCLE VERSION_33" if $mid > 0 || $minor >= 33;
+  }
 
   my @correct_inc = map {s/^-I// && $_} split /\s+/,$cflags;
   check_for_stray_headers($includedir,@correct_inc);


### PR DESCRIPTION
Also applied 'bricas' Patch to detect version 2.1.x as being after 2.0.33, which I notice is Pull request #9 (https://github.com/lstein/Perl-GD/pull/9/files).

However when I applied that patch I was still left without Animated GIF support until I also updated Build.PL.

That was because 2.1.1-dev@ returns GD_GIFANIM!

Nick(c)
