### PR TITLE
Corrected the META_MERGE for github repo

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -243,12 +243,14 @@ my $build = Module::Build->new(
     extra_compiler_flags => $DEFINES,
     script_files        => 'bdf_scripts',
     meta_merge => {
-	'meta-spec' => { version => 2 },
-	x_repository => {
-	    type => 'git',
-	    url  => 'git://github.com/lstein/Perl-GD.git',
-	    web  => 'https://github.com/lstein/Perl-GD',
-	},
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'git://github.com/lstein/Perl-GD.git',
+                web  => 'https://github.com/lstein/Perl-GD',
+            },
+        },
     }
     );
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -263,13 +263,14 @@ WriteMakefile(
     ( $MAKEMAKER_VERSION > 6.45 ? (
 	META_MERGE => {
 	    'meta-spec' => { version => 2 },
-	    repository => {
-		type => 'git',
-		url  => 'git://github.com/lstein/Perl-GD.git',
-		web  => 'https://github.com/lstein/Perl-GD',
-	    },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'git://github.com/lstein/Perl-GD.git',
+                web  => 'https://github.com/lstein/Perl-GD',
+            },
         },
-    ):()),
+    }):()),
 );
 
 exit 0;


### PR DESCRIPTION
Hi Lincoln,

The metadata for this dist doesn't give the github repo in the expected `repository` key, but has it in the `x_repository` key, which means that various tools like MetaCPAN don't find it.

This corrects the `META_MERGE`, which was missing the `resources` key.

With this corrected, the distribution would become a candidate for the [CPAN Pull Request Challenge](http://cpan-prc.org). It would be great if you could do a release with correct repo metadata.

Cheers,
Neil
