### PR TITLE
fix incorrect parsing of gdlib-config output when it returns empty values

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -264,12 +264,12 @@ sub try_to_autoconfigure {
   my ($version) = $config =~ /^GD library\s+(\S+)/m;
   warn "Configuring for libgd version $version.\n";
 
-  my ($cflags)     = $config =~ /^cflags:\s*?(.*?)$/m;
-  my ($ldflags)    = $config =~ /^ldflags:\s*?(.*?)$/m;
-  my ($libs)       = $config =~ /^libs:\s*?(.*?)$/m;
-  my ($libdir)     = $config =~ /^libdir:\s*?(.*?)$/m;
-  my ($features)   = $config =~ /^features:\s*?(.*?)$/m;
-  my ($includedir) = $config =~ /^includedir:\s*?(.*?)$/m;
+  my ($cflags)     = $config =~ /^cflags:     \h*(.*?)\h*$/mx;
+  my ($ldflags)    = $config =~ /^ldflags:    \h*(.*?)\h*$/mx;
+  my ($libs)       = $config =~ /^libs:       \h*(.*?)\h*$/mx;
+  my ($libdir)     = $config =~ /^libdir:     \h*(.*?)\h*$/mx;
+  my ($features)   = $config =~ /^features:   \h*(.*?)\h*$/mx;
+  my ($includedir) = $config =~ /^includedir: \h*(.*?)\h*$/mx;
 
   @$INC          = map {s/^-I// && "-I$_"} split /\s+/,$cflags;
   @$LIBPATH      = map {s/^-L// && "-L$_"} split /\s+/,$ldflags;

--- a/Build.PL
+++ b/Build.PL
@@ -264,12 +264,12 @@ sub try_to_autoconfigure {
   my ($version) = $config =~ /^GD library\s+(\S+)/m;
   warn "Configuring for libgd version $version.\n";
 
-  my ($cflags)     = $config =~ /^cflags:\s+(.+)/m;
-  my ($ldflags)    = $config =~ /^ldflags:\s+(.+)/m;
-  my ($libs)       = $config =~ /^libs:\s+(.+)/m;
-  my ($libdir)     = $config =~ /^libdir:\s+(.+)/m;
-  my ($features)   = $config =~ /^features:\s+(.+)/m;
-  my ($includedir) = $config =~ /^includedir:\s+(.+)/m;
+  my ($cflags)     = $config =~ /^cflags:\s*?(.*?)$/m;
+  my ($ldflags)    = $config =~ /^ldflags:\s*?(.*?)$/m;
+  my ($libs)       = $config =~ /^libs:\s*?(.*?)$/m;
+  my ($libdir)     = $config =~ /^libdir:\s*?(.*?)$/m;
+  my ($features)   = $config =~ /^features:\s*?(.*?)$/m;
+  my ($includedir) = $config =~ /^includedir:\s*?(.*?)$/m;
 
   @$INC          = map {s/^-I// && "-I$_"} split /\s+/,$cflags;
   @$LIBPATH      = map {s/^-L// && "-L$_"} split /\s+/,$ldflags;

--- a/Build.PL
+++ b/Build.PL
@@ -276,8 +276,11 @@ sub try_to_autoconfigure {
   @$LIBS         = split /\s+/,$libs;
 
   push @$LIBS,"-lgd";
-  push @$LIBPATH,"-L$libdir";
-  ($$lib_gd_path = $libdir) =~ s!/[^/]+$!!;
+  if ( $libdir ) {
+      push @$LIBPATH,"-L$libdir";
+      ($$lib_gd_path = $libdir) =~ s!/[^/]+$!!;
+  }
+
   $$options      = $features;
 
   my ($minor, $patch)    = $version =~ /^2\.(\d+)\.(\d+)$/;


### PR DESCRIPTION
See https://rt.cpan.org/Public/Bug/Display.html?id=118204

Example gdlib output that causes the behavior:

GD library 2.0.34
includedir: /usr/include
cflags: -I/usr/include
ldflags:
libs: -lXpm -lX11 -ljpeg -lfontconfig -lfreetype -lpng12 -lz -lm
libdir:
features: GD_XPM GD_JPEG GD_FONTCONFIG GD_FREETYPE GD_PNG GD_GIF GD_GIFANIM GD_OPENPOLYGON

When this is parsed in try_to_autoconfigure(), the libdir and ldflags lines are incorrectly parsed, e.g.

   270 my ($libdir) = $config =~ /^libdir:\s+(.+)/m;

results in

  $libdir = 'features: GD_XPM GD_JPEG GD_FONTCONFIG GD_FREETYPE GD_PNG GD_GIF GD_GIFANIM GD_OPENPOLYGON'
