### PR TITLE
Added additional logic for bdf2gdfont.pl creation

### DIFF
--- a/bdf_scripts/bdf2gdfont.PLS
+++ b/bdf_scripts/bdf2gdfont.PLS
@@ -8,6 +8,10 @@ chdir dirname($0);
 $file = basename($0, '.PL','.PLS');
 $file .= $^O eq 'VMS' ? '.com' : '.pl';
 
+if (-e $file) {
+    unlink($file);
+}
+
 open OUT,">$file" or die "Can't create $file: $!";
 
 print "Extracting $file (with variable substitutions)\n";


### PR DESCRIPTION
In one of the CPAN releases the `bdf_scripts/bdf2gdfont.pl` file was already present causing the installation with `Makefile.PL` to fail.

Improved the `bdf_scripts/bdf2gdfont.PLS` script resilience by deleting the old file before opening the new one.