### PR TITLE
Makefile.PL: fix cross-compilation with gdlib.pc

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,8 +47,6 @@ If you want to try to compile anyway, please rerun this script with the option -
 END
 }
 
-@INC     = qw(-I/usr/include -I/usr/include/gd) unless @INC;
-@LIBPATH = qw(-L/usr/lib/X11 -L/usr/X11R6/lib -L/usr/X11/lib -L/usr/lib) unless @LIBPATH;
 @LIBS    = qw(-lgd) unless @LIBS;
 
 # support for AMD64 libraries


### PR DESCRIPTION
Cross-compilation will fail if gdlib.pc does not contain any cflags.
Indeed, if cflags is empty, Makefile.PL will use the default value for
INC (i.e. -I/usr/include -I/usr/include/gd)

It should be noted that gdlib-config has been dropped from gd since
version 2.3.0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>