### PR TITLE
copyRotated rotates counter clockwise

### DIFF
--- a/lib/GD.pm
+++ b/lib/GD.pm
@@ -1264,7 +1264,7 @@ image is a palette image.
 B<				$srcX,$srcY,$width,$height,$angle)>
 
 Like copyResized() but the $angle argument specifies an arbitrary
-amount to rotate the image clockwise (in degrees).  In addition, $dstX
+amount to rotate the image counter clockwise (in degrees).  In addition, $dstX
 and $dstY species the B<center> of the destination image, and not the
 top left corner.
 


### PR DESCRIPTION
hello see also  https://libgd.github.io/manuals/2.3.1/files/gd-c.html#gdImageCopyRotated
and my post at perlmonks: https://www.perlmonks.org/?node_id=11128690

I dont know if also ellipsis description must to be corrected

thanks for looking