### PR TITLE
POD: Remove indirect object constructors from example code snippets

### DIFF
--- a/lib/GD.pm
+++ b/lib/GD.pm
@@ -128,7 +128,7 @@ GD.pm - Interface to Gd Graphics Library
     use GD;
 
     # create a new image
-    $im = new GD::Image(100,100);
+    $im = GD::Image->new(100,100);
 
     # allocate some colors
     $white = $im->colorAllocate(255,255,255);
@@ -199,7 +199,7 @@ A Simple Example:
 	use GD;
 
 	# create a new image
-	$im = new GD::Image(100,100);
+	$im = GD::Image->new(100,100);
 
 	# allocate some colors
 	$white = $im->colorAllocate(255,255,255);
@@ -282,7 +282,7 @@ The new() method is the main constructor for the GD::Image class.
 Called with two integer arguments, it creates a new blank image of the
 specified width and height. For example:
 
-	$myImage = new GD::Image(100,100) || die;
+	$myImage = GD::Image->new(100,100) || die;
 
 This will create an image that is 100 x 100 pixels wide.  If you don't
 specify the dimensions, a default of 64 x 64 will be chosen.
@@ -352,11 +352,11 @@ and read the PNG information from it.
   Example1:
 
   open (PNG,"barnswallow.png") || die;
-  $myImage = newFromPng GD::Image(\*PNG) || die;
+  $myImage = GD::Image->newFromPng(\*PNG) || die;
   close PNG;
 
   Example2:
-  $myImage = newFromPng GD::Image('barnswallow.png');
+  $myImage = GD::Image->newFromPng('barnswallow.png');
 
 To get information about the size and color usage of the information,
 you can call the image query methods described below. Images created
@@ -397,7 +397,7 @@ This works in exactly the same way as C<newFromPng>, but reads the
 contents of an X Bitmap (black & white) file:
 
 	open (XBM,"coredump.xbm") || die;
-	$myImage = newFromXbm GD::Image(\*XBM) || die;
+	$myImage = GD::Image->newFromXbm(\*XBM) || die;
 	close XBM;
 
 There is no newFromXbmData() function, because there is no
@@ -409,7 +409,7 @@ This works in exactly the same way as C<newFromPng>, but reads the
 contents of an Windows BMP Bitmap file:
 
 	open (BMP,"coredump.bmp") || die;
-	$myImage = newFromWBMP GD::Image(\*BMP) || die;
+	$myImage = GD::Image->newFromWBMP(\*BMP) || die;
 	close BMP;
 
 There is no newFromWBMPData() function, because there is no
@@ -425,7 +425,7 @@ rare case when you need to read and write the image to disk quickly.
 It's not intended for regular use, because, unlike PNG or JPEG, no
 image compression is performed and these files can become B<BIG>.
 
-	$myImage = newFromGd GD::Image("godzilla.gd") || die;
+	$myImage = GD::Image->newFromGd("godzilla.gd") || die;
 	close GDF;
 
 =item B<$image = GD::Image-E<gt>newFromGd2($file)>
@@ -456,7 +456,7 @@ is unlike the other newFrom() functions because it does not take a
 filehandle.  This difference comes from an inconsistency in the
 underlying gd library.
 
-	$myImage = newFromXpm GD::Image('earth.xpm') || die;
+	$myImage = GD::Image->newFromXpm('earth.xpm') || die;
 
 This function is only available if libgd was compiled with XPM
 support.  
@@ -804,7 +804,7 @@ current index of the transparent color, or -1 if none.
 Example:
 
 	open(PNG,"test.png");
-	$im = newFromPng GD::Image(PNG);
+	$im = GD::Image->newFromPng(PNG);
 	$white = $im->colorClosest(255,255,255); # find white
 	$im->transparent($white);
 	binmode STDOUT;
@@ -837,7 +837,7 @@ non-colored parts don't overwrite other parts of your image.
 Example:
 
 	# Create a brush at an angle
-	$diagonal_brush = new GD::Image(5,5);
+	$diagonal_brush = GD::Image->new(5,5);
 	$white = $diagonal_brush->colorAllocate(255,255,255);
 	$black = $diagonal_brush->colorAllocate(0,0,0);
 	$diagonal_brush->transparent($white);
@@ -1011,7 +1011,7 @@ with a pattern.
 Example:
 
 	# read in a fill pattern and set it
-	$tile = newFromPng GD::Image('happyface.png');
+	$tile = GD::Image->newFromPng('happyface.png');
 	$myImage->setTile($tile); 
 
 	# draw the rectangle, filling it with the pattern
@@ -1027,7 +1027,7 @@ colors gdBrushed, gdStyled and gdStyledBrushed can be specified.
 
 Example:
 
-	$poly = new GD::Polygon;
+	$poly = GD::Polygon->new;
 	$poly->addPt(50,0);
 	$poly->addPt(99,99);
 	$poly->addPt(0,99);
@@ -1045,7 +1045,7 @@ You need libgd 2.0.33 or higher to use this feature.
 
 Example:
 
-	$poly = new GD::Polygon;
+	$poly = GD::Polygon->new;
 	$poly->addPt(50,0);
 	$poly->addPt(99,99);
 	$poly->addPt(0,99);
@@ -1060,7 +1060,7 @@ with a pattern.
 Example:
 
 	# make a polygon
-	$poly = new GD::Polygon;
+	$poly = GD::Polygon->new;
 	$poly->addPt(50,0);
 	$poly->addPt(99,99);
 	$poly->addPt(0,99);
@@ -1180,9 +1180,9 @@ destination regions must not overlap or strange things will happen.
 
 Example:
 
-	$myImage = new GD::Image(100,100);
+	$myImage = GD::Image->new(100,100);
 	... various drawing stuff ...
-	$srcImage = new GD::Image(50,50);
+	$srcImage = GD::Image->new(50,50);
 	... more drawing stuff ...
 	# copy a 25x25 pixel region from $srcImage to
 	# the rectangle starting at (10,10) in $myImage
@@ -1196,7 +1196,7 @@ palette and other nonessential details.
 
 Example:
 
-	$myImage = new GD::Image(100,100);
+	$myImage = GD::Image->new(100,100);
 	... various drawing stuff ...
         $copy = $myImage->clone;
 
@@ -1213,9 +1213,9 @@ solid rectangle.
 
 Example:
 
-	$myImage = new GD::Image(100,100);
+	$myImage = GD::Image->new(100,100);
 	... various drawing stuff ...
-	$redImage = new GD::Image(50,50);
+	$redImage = GD::Image->new(50,50);
 	... more drawing stuff ...
 	# copy a 25x25 pixel region from $srcImage to
 	# the rectangle starting at (10,10) in $myImage, merging 50%
@@ -1241,9 +1241,9 @@ image to accommodate the size requirements.
 
 Example:
 
-	$myImage = new GD::Image(100,100);
+	$myImage = GD::Image->new(100,100);
 	... various drawing stuff ...
-	$srcImage = new GD::Image(50,50);
+	$srcImage = GD::Image->new(50,50);
 	... more drawing stuff ...
 	# copy a 25x25 pixel region from $srcImage to
 	# a larger rectangle starting at (10,10) in $myImage
@@ -1825,7 +1825,7 @@ Quickdraw library).  Also see L<GD::Polyline>.
 
 Create an empty polygon with no vertices.
 
-	$poly = new GD::Polygon;
+	$poly = GD::Polygon->new;
 
 =item B<$poly-E<gt>addPt($x,$y)>
 

--- a/lib/GD/Polyline.pm
+++ b/lib/GD/Polyline.pm
@@ -23,8 +23,8 @@ package GD::Polyline;
 ############################################################################
 #
 # What's this?  A class with nothing but a $VERSION and @ISA?
-# Below, this module overrides and adds several modules to 
-# the parent class, GD::Polygon.  Those updated/new methods 
+# Below, this module overrides and adds several modules to
+# the parent class, GD::Polygon.  Those updated/new methods
 # act on polygons and polylines, and sometimes those behaviours
 # vary slightly based on whether the object is a polygon or polyline.
 #
@@ -60,13 +60,13 @@ sub centroid {
     my ($self, $scale) = @_;
     my ($cx,$cy);
     $scale = 1 unless defined $scale;
-    
+
     map {$cx += $_->[0]; $cy += $_->[1]} $self->vertices();
-    
+
     $cx *= $scale / $self->length();
     $cy *= $scale / $self->length();
 
-	return ($cx, $cy);    
+	return ($cx, $cy);
 }
 
 
@@ -75,19 +75,19 @@ sub segLength {
     my @points = $self->vertices();
 
 	my ($p1, $p2, @segLengths);
-	
+
 	$p1 = shift @points;
-	
+
 	# put the first vertex on the end to "close" a polygon, but not a polyline
 	push @points, $p1 unless $self->isa('GD::Polyline');
-	
+
 	while ($p2 = shift @points) {
 		push @segLengths, _len($p1, $p2);
 		$p1 = $p2;
 	}
-	
+
 	return @segLengths if wantarray;
-	
+
 	my $sum;
 	map {$sum += $_} @segLengths;
 	return $sum;
@@ -98,17 +98,17 @@ sub segAngle {
     my @points = $self->vertices();
 
 	my ($p1, $p2, @segAngles);
-	
+
 	$p1 = shift @points;
-	
+
 	# put the first vertex on the end to "close" a polygon, but not a polyline
 	push @points, $p1 unless $self->isa('GD::Polyline');
-	
+
 	while ($p2 = shift @points) {
 		push @segAngles, _angle_reduce2(_angle($p1, $p2));
 		$p1 = $p2;
 	}
-	
+
 	return @segAngles;
 }
 
@@ -123,16 +123,16 @@ sub vertexAngle {
 
 	# put the first vertex on the end to "close" a polygon, but not a polyline
 	push @points, $p2 unless $self->isa('GD::Polyline');
-	
+
 	while ($p3 = shift @points) {
 		push @vertexAngle, _angle_reduce2(_angle($p1, $p2, $p3));
 		($p1, $p2) = ($p2, $p3);
 	}
-	
+
 	$vertexAngle[0] = undef if defined $vertexAngle[0] and $self->isa("GD::Polyline");
-	
+
 	return @vertexAngle if wantarray;
-	
+
 }
 
 
@@ -141,51 +141,51 @@ sub toSpline {
     my $self = shift;
     my @points = $self->vertices();
 
-	# put the first vertex on the end to "close" a polygon, but not a polyline    
+	# put the first vertex on the end to "close" a polygon, but not a polyline
     push @points, [$self->getPt(0)] unless $self->isa('GD::Polyline');
 
 	unless (@points > 1 and @points % 3 == 1) {
 	    carp "Attempt to call toSpline() with invalid set of control points";
 		return undef;
 	}
-    
+
     my ($ap1, $dp1, $dp2, $ap2); # ap = anchor point, dp = director point
     $ap1 = shift @points;
 
 	my $bez = new ref($self);
 
     $bez->addPt(@$ap1);
-    
+
     while (@points) {
     	($dp1, $dp2, $ap2) = splice(@points, 0, 3);
-    	
+
 		for (1..$bezSegs) {
-			my ($t0, $t1, $c1, $c2, $c3, $c4, $x, $y); 
-			
+			my ($t0, $t1, $c1, $c2, $c3, $c4, $x, $y);
+
 			$t1 = $_/$bezSegs;
 			$t0 = (1 - $t1);
-			
+
 			# possible optimization:
-			# these coefficient could be calculated just once and 
+			# these coefficient could be calculated just once and
 			# cached in an array for a given value of $bezSegs
-			
+
 			$c1 =     $t0 * $t0 * $t0;
 			$c2 = 3 * $t0 * $t0 * $t1;
 			$c3 = 3 * $t0 * $t1 * $t1;
 			$c4 =     $t1 * $t1 * $t1;
-	
+
 			$x = $c1 * $ap1->[0] + $c2 * $dp1->[0] + $c3 * $dp2->[0] + $c4 * $ap2->[0];
 			$y = $c1 * $ap1->[1] + $c2 * $dp1->[1] + $c3 * $dp2->[1] + $c4 * $ap2->[1];
-		
+
 			$bez->addPt($x, $y);
 		}
-    	
+
     	$ap1 = $ap2;
     }
-    
+
     # remove the last anchor point if this is a polygon -- since it will autoclose without it
 	$bez->deletePt($bez->length()-1) unless $self->isa('GD::Polyline');
-    
+
 	return $bez;
 }
 
@@ -197,7 +197,7 @@ sub addControlPoints {
 	    carp "Attempt to call addControlPoints() with too few vertices in polyline";
 		return undef;
 	}
-	
+
 	my $points = scalar(@points);
 	my @segAngles  = $self->segAngle();
 	my @segLengths = $self->segLength();
@@ -207,12 +207,12 @@ sub addControlPoints {
 
 	# this loop goes about creating polylines -- here called control segments --
 	# that hold the control points for the final set of control points
-	
+
 	# each control segment has three points, and these are colinear
-	
+
 	# the first and last will ultimately be "director points", and
 	# the middle point will ultimately be an "anchor point"
-	
+
 	for my $i (0..$#points) {
 
 		$controlSeg = new GD::Polyline;
@@ -224,26 +224,26 @@ sub addControlPoints {
 			$controlSeg->addPt($ptX, $ptY);	# director point
 			$controlSeg->addPt($ptX, $ptY);	# anchor point
 			$controlSeg->addPt($ptX, $ptY);	# director point
-			next;	
+			next;
 		}
-				
+
 		$prevLen = $segLengths[$i-1];
 		$nextLen = $segLengths[$i];
 		$prevAngle = $segAngles[$i-1];
-		$nextAngle = $segAngles[$i];		
-		
+		$nextAngle = $segAngles[$i];
+
 		# make a control segment with control points (director points)
 		# before and after the point from the polyline (anchor point)
-		
+
 		$controlSeg->addPt($ptX - $csr * $prevLen, $ptY);	# director point
-		$controlSeg->addPt($ptX                  , $ptY);	# anchor point  
+		$controlSeg->addPt($ptX                  , $ptY);	# anchor point
 		$controlSeg->addPt($ptX + $csr * $nextLen, $ptY);	# director point
 
 		# note that:
 		# - the line is parallel to the x-axis, as the points have a common $ptY
 		# - the points are thus clearly colinear
 		# - the director point is a distance away from the anchor point in proportion to the length of the segment it faces
-		
+
 		# now, we must come up with a reasonable angle for the control seg
 		#  first, "unwrap" $nextAngle w.r.t. $prevAngle
 		$nextAngle -= 2*pi() until $nextAngle < $prevAngle + pi();
@@ -251,42 +251,42 @@ sub addControlPoints {
 		#  next, use seg lengths as an inverse weighted average
 		#  to "tip" the control segment toward the *shorter* segment
 		$thisAngle = ($nextAngle * $prevLen + $prevAngle * $nextLen) / ($prevLen + $nextLen);
-				       
+
 		# rotate the control segment to $thisAngle about it's anchor point
 		$controlSeg->rotate($thisAngle, $ptX, $ptY);
-		
+
 	} continue {
 		# save the control segment for later
 		push @controlSegs, $controlSeg;
-		
+
 	}
-	
+
 	# post process
-	
+
 	my $controlPoly = new ref($self);
 
 	# collect all the control segments' points in to a single control poly
-	
+
 	foreach my $cs (@controlSegs) {
 		foreach my $pt ($cs->vertices()) {
 			$controlPoly->addPt(@$pt);
 		}
 	}
-	
+
 	# final clean up based on poly type
-	
+
 	if ($controlPoly->isa('GD::Polyline')) {
 		# remove the first and last control point
-		# since they are director points ... 
+		# since they are director points ...
 		$controlPoly->deletePt(0);
 		$controlPoly->deletePt($controlPoly->length()-1);
 	} else {
 		# move the first control point to the last control point
-		# since it is supposed to end with two director points ... 
+		# since it is supposed to end with two director points ...
 		$controlPoly->addPt($controlPoly->getPt(0));
 		$controlPoly->deletePt(0);
 	}
-	
+
 	return $controlPoly;
 }
 
@@ -313,7 +313,7 @@ use Math::Trig;
 # Find the angle of... well, depends on the number of arguments:
 # - one point: the angle from x-axis to the point (origin is the center)
 # - two points: the angle of the vector defined from point1 to point2
-# - three points: 
+# - three points:
 # Internal function; NOT a class or object method.
 #
 sub _angle {
@@ -337,7 +337,7 @@ sub _angle {
 sub _subtract {
 	my ($p1, $p2) = @_;
 #	print(_print_point($p2), "-", _print_point($p1), "\n");
-	return [$p2->[0]-$p1->[0], $p2->[1]-$p1->[1]];	
+	return [$p2->[0]-$p1->[0], $p2->[1]-$p1->[1]];
 }
 
 # _print_point()
@@ -381,7 +381,7 @@ sub GD::Image::polyline {
     my $self = shift;	# the GD::Image
     my $p    = shift;	# the GD::Polyline (or GD::Polygon)
     my $c    = shift;	# the color
-    
+
     my @points = $p->vertices();
     my $p1 = shift @points;
     my $p2;
@@ -389,16 +389,16 @@ sub GD::Image::polyline {
 	    $self->line(@$p1, @$p2, $c);
     	$p1 = $p2;
     }
-}	    
+}
 
 sub GD::Image::polydraw {
     my $self = shift;	# the GD::Image
     my $p    = shift;	# the GD::Polyline or GD::Polygon
     my $c    = shift;	# the color
-    
+
    	return $self->polyline($p, $c) if $p->isa('GD::Polyline');
-   	return $self->polygon($p, $c);    	
-}	    
+   	return $self->polygon($p, $c);
+}
 
 
 1;
@@ -416,14 +416,14 @@ GD::Polyline - Polyline object and Polygon utilities (including splines) for use
 	use GD::Polyline;
 
 	# create an image
-	$image = new GD::Image (500,300);
+	$image = GD::Image->new (500,300);
 	$white  = $image->colorAllocate(255,255,255);
 	$black  = $image->colorAllocate(  0,  0,  0);
 	$red    = $image->colorAllocate(255,  0,  0);
-	
+
 	# create a new polyline
-	$polyline = new GD::Polyline;
-			
+	$polyline = GD::Polyline->new;
+
 	# add some points
 	$polyline->addPt(  0,  0);
 	$polyline->addPt(  0,100);
@@ -432,16 +432,16 @@ GD::Polyline - Polyline object and Polygon utilities (including splines) for use
 
 	# polylines can use polygon methods (and vice versa)
 	$polyline->offset(200,100);
-	
+
 	# rotate 60 degrees, about the centroid
-	$polyline->rotate(3.14159/3, $polyline->centroid()); 
-	
+	$polyline->rotate(3.14159/3, $polyline->centroid());
+
 	# scale about the centroid
-	$polyline->scale(1.5, 2, $polyline->centroid());  
-	
+	$polyline->scale(1.5, 2, $polyline->centroid());
+
 	# draw the polyline
 	$image->polydraw($polyline,$black);
-	
+
 	# create a spline, which is also a polyine
 	$spline = $polyline->addControlPoints->toSpline;
 	$image->polydraw($spline,$red);
@@ -480,7 +480,7 @@ C<GD::Polyline-E<gt>new> I<class method>
 
 Create an empty polyline with no vertices.
 
-	$polyline = new GD::Polyline;
+	$polyline = GD::Polyline->new;
 
 	$polyline->addPt(  0,  0);
 	$polyline->addPt(  0,100);
@@ -489,11 +489,11 @@ Create an empty polyline with no vertices.
 
 	$image->polydraw($polyline,$black);
 
-In fact GD::Polyline is a subclass of GD::Polygon, 
+In fact GD::Polyline is a subclass of GD::Polygon,
 so all polygon methods (such as B<offset> and B<transform>)
 may be used on polylines.
 Some new methods have thus been added to GD::Polygon (such as B<rotate>)
-and a few updated/modified/enhanced (such as B<scale>) I<in this module>.  
+and a few updated/modified/enhanced (such as B<scale>) I<in this module>.
 See section "New or Updated GD::Polygon Methods" for more info.
 
 =back
@@ -534,7 +534,7 @@ flip the polything top to bottom about line y = 100, use:
 The following methods are added to GD::Polygon, and thus can be used
 by polygons and polylines.
 
-Don't forget: a polyline is a GD::Polygon, so GD::Polygon methods 
+Don't forget: a polyline is a GD::Polygon, so GD::Polygon methods
 like offset() can be used, and they can be used in
 GD::Image methods like filledPolygon().
 
@@ -563,8 +563,8 @@ For example, to rotate something 180 degrees about it's centroid:
 
 	$poly->rotate(3.14159, $poly->centroid());
 
-$scale is optional; if supplied, $cx and $cy are multiplied by $scale 
-before returning.  The main use of this is to shift an polything to the 
+$scale is optional; if supplied, $cx and $cy are multiplied by $scale
+before returning.  The main use of this is to shift an polything to the
 origin like this:
 
 	$poly->offset($poly->centroid(-1));
@@ -597,14 +597,14 @@ C<@vertexAngles = $poly-E<gt>vertexAngle()> I<object method>
 
 Returns an array of the angles between the segment into and out of each vertex.
 For polylines, the vertex angle at vertex 0 and the last vertex are not defined;
-however $vertexAngle[0] will be undef so that $vertexAngle[1] will correspond to 
+however $vertexAngle[0] will be undef so that $vertexAngle[1] will correspond to
 vertex 1.
 
 Returned angles will be on the interval 0 <= $angle < 2 * pi and
 angles increase in a clockwise direction.
 
 Note that this calculation does not attempt to figure out the "interior" angle
-with respect to "inside" or "outside" the polygon, but rather, 
+with respect to "inside" or "outside" the polygon, but rather,
 just the angle between the adjacent segments
 in a clockwise sense.  Thus a polygon with all right angles will have vertex
 angles of either pi/2 or 3*pi/2, depending on the way the polygon was "wound".
@@ -616,12 +616,12 @@ C<$poly-E<gt>toSpline()> I<object method & factory method>
 Create a new polything which is a reasonably smooth curve
 using cubic spline algorithms, often referred to as Bezier
 curves.  The "source" polything is called the "control polything".
-If it is a polyline, the control polyline must 
+If it is a polyline, the control polyline must
 have 4, 7, 10, or some number of vertices of equal to 3n+1.
-If it is a polygon, the control polygon must 
+If it is a polygon, the control polygon must
 have 3, 6, 9, or some number of vertices of equal to 3n.
 
-	$spline = $poly->toSpline();	
+	$spline = $poly->toSpline();
 	$image->polydraw($spline,$red);
 
 In brief, groups of four points from the control polyline
@@ -666,7 +666,7 @@ If you have a polyline, and you have already put your
 control points where you want them, call toSpline() directly.
 Remember, only every third vertex will be "on" the spline.
 
-You get something that looks like the spline "inscribed" 
+You get something that looks like the spline "inscribed"
 inside the control polyline.
 
 =item +
@@ -675,19 +675,19 @@ If you have a polyline, and you want all of its vertices on
 the resulting spline, call addControlPoints() and then
 toSpline():
 
-	$control = $polyline->addControlPoints();	
-	$spline  = $control->toSpline();	
+	$control = $polyline->addControlPoints();
+	$spline  = $control->toSpline();
 	$image->polyline($spline,$red);
 
-You get something that looks like the control polyline "inscribed" 
+You get something that looks like the control polyline "inscribed"
 inside the spline.
 
 =back
 
-Adding "good" control points is subjective; this particular 
-algorithm reveals its author's tastes.  
+Adding "good" control points is subjective; this particular
+algorithm reveals its author's tastes.
 In the future, you may be able to alter the taste slightly
-via parameters to the algorithm.  For The Hubristic: please 
+via parameters to the algorithm.  For The Hubristic: please
 build a better one!
 
 And for The Impatient: note that addControlPoints() returns a
@@ -704,12 +704,12 @@ if you'd like:
 
 =item C<polyline>
 
-C<$image-E<gt>polyline(polyline,color)> I<object method> 
+C<$image-E<gt>polyline(polyline,color)> I<object method>
 
 	$image->polyline($polyline,$black)
 
-This draws a polyline with the specified color.  
-Both real color indexes and the special 
+This draws a polyline with the specified color.
+Both real color indexes and the special
 colors gdBrushed, gdStyled and gdStyledBrushed can be specified.
 
 Neither the polyline() method or the polygon() method are very
@@ -719,12 +719,12 @@ the object type.
 
 =item C<polydraw>
 
-C<$image-E<gt>polydraw(polything,color)> I<object method> 
+C<$image-E<gt>polydraw(polything,color)> I<object method>
 
 	$image->polydraw($poly,$black)
 
-This method draws the polything as expected (polygons are closed, 
-polylines are open) by simply checking the object type and calling 
+This method draws the polything as expected (polygons are closed,
+polylines are open) by simply checking the object type and calling
 either $image->polygon() or $image->polyline().
 
 =back
@@ -744,24 +744,24 @@ On the drawing board are additional features such as:
 	- polygon winding algorithms (to determine if a point is "inside" or "outside" the polygon)
 
 	- new polygon from bounding box
-	
+
 	- find bounding polygon (tightest fitting simple convex polygon for a given set of vertices)
-	
+
 	- addPts() method to add many points at once
-	
+
 	- clone() method for polygon
-	
+
 	- functions to interwork GD with SVG
-	
+
 Please provide input on other possible features you'd like to see.
 
 =head1 Author
 
-This module has been written by Daniel J. Harasty.  
+This module has been written by Daniel J. Harasty.
 Please send questions, comments, complaints, and kudos to him
 at harasty@cpan.org.
 
-Thanks to Lincoln Stein for input and patience with me and this, 
+Thanks to Lincoln Stein for input and patience with me and this,
 my first CPAN contribution.
 
 =head1 Copyright Information
@@ -770,8 +770,8 @@ The Polyline.pm module is copyright 2002, Daniel J. Harasty.  It is
 distributed under the same terms as Perl itself.  See the "Artistic
 License" in the Perl source code distribution for licensing terms.
 
-The latest version of Polyline.pm is available at 
-your favorite CPAN repository and/or 
+The latest version of Polyline.pm is available at
+your favorite CPAN repository and/or
 along with GD.pm by Lincoln D. Stein at http://stein.cshl.org/WWW/software/GD.
 
 =cut

--- a/lib/GD/Simple.pm
+++ b/lib/GD/Simple.pm
@@ -65,7 +65,7 @@ http://perlmaven.com/drawing-images-using-gd-simple.
     $img->line(50);  # 50 pixel line
 
     # draw a cyan polygon edged in blue
-    my $poly = new GD::Polygon;
+    my $poly = GD::Polygon->new;
     $poly->addPt(150,100);
     $poly->addPt(199,199);
     $poly->addPt(100,199);


### PR DESCRIPTION
Updated the POD in 3 files to change the constructor examples that were using indirect object notation to using class-method notation, per https://rt.cpan.org/Ticket/Display.html?id=139961 and best-practice recommendations from `perldoc perlobj`.

* GD.pm: changed 23 examples of `= new* GD::xxx` to `= GD::xxx->new*`
* Polyline.pm: changed 3 examples of `= new GD::xxx` to `= GD::xxx->new`
    * did _not_ change the actual implementation code on line 218
* Simple.pm: changed 1 example of `= new GD::Polygon` to `= GD::Polygon->new`
