### PR TITLE
Fix copy and paste error in updated image format support

### DIFF
--- a/lib/GD/Image.pm
+++ b/lib/GD/Image.pm
@@ -229,11 +229,11 @@ sub newFromTiff {
 }
 
 sub newFromXbm {
-    croak("Usage: newFromTiff(class,filehandle)") unless @_==2;
+    croak("Usage: newFromXbm(class,filehandle)") unless @_==2;
     my($class,$f) = @_;
     my $fh = $class->_make_filehandle($f);
     binmode($fh);
-    $class->_newFromTiff($fh);
+    $class->_newFromXbm($fh);
 }
 
 sub newFromWebp {
@@ -252,7 +252,7 @@ sub newFromHeif {
     $class->_newFromHeif($fh);
 }
 
-sub newFromHeif {
+sub newFromAvif {
     croak("Usage: newFromAvif(class,filehandle)") unless @_==2;
     my($class,$f) = @_;
     my $fh = $class->_make_filehandle($f);

--- a/lib/GD/Image_pm.PL
+++ b/lib/GD/Image_pm.PL
@@ -317,19 +317,6 @@ sub newFromXbm {
 !NO!SUBS!
 }
 
-if ($DEFINES =~ /HAVE_TIFF/) {
-  print OUT <<'!NO!SUBS!'
-sub newFromXbm {
-    croak("Usage: newFromTiff(class,filehandle)") unless @_==2;
-    my($class,$f) = @_;
-    my $fh = $class->_make_filehandle($f);
-    binmode($fh);
-    $class->_newFromTiff($fh);
-}
-
-!NO!SUBS!
-}
-
 if ($DEFINES =~ /HAVE_WEBP/) {
   print OUT <<'!NO!SUBS!'
 sub newFromWebp {


### PR DESCRIPTION
This fixes a problem that manifests in GDGraph with GD 2.75:
https://rt.cpan.org/Public/Bug/Display.html?id=140910
```
: Not a TIFF or MDI file, bad magic number 25635 (0x6423).
GD Warning: Cannot open TIFF imagegdImageCreateFromTiff error at /usr/local/lib/perl5/site_perl/5.34.0/x86_64-linux-gnu/GD/Image.pm line 256.
t/bugfixes.t ...................
Dubious, test returned 25 (wstat 6400, 0x1900)
Failed 14/33 subtests
```