### PR TITLE
fix RT 141125 unused variables GH CI failure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+2.77    * fix RT 141125 unused file failure in GH CI, by PhilterPaper
 2.76    * fix broken TIFF and AVIF support, PR #43 by Paul Howarth
         * re-enable XBM support (always on)
         * provide xbm magic support (a hack, for GD::Graph)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2.77    * fix RT 141125 unused file failure in GH CI, by PhilterPaper
+2.77    * fix RT 141125 unused variable failure in GH CI, by PhilterPaper
 2.76    * fix broken TIFF and AVIF support, PR #43 by Paul Howarth
         * re-enable XBM support (always on)
         * provide xbm magic support (a hack, for GD::Graph)
@@ -16,7 +16,7 @@
         * added Github actions (for PR's)
         * fix poly->transform documentation RT #140043
         * fix GD,GD2 detection and tests RT #139399 (since libgd 2.3.3)
-          fixed tests by HÂkon HÊgland.
+          fixed tests by H√•kon H√¶gland.
         * POD: Remove indirect object constructors from example code snippet (PR #39)
         * patch from Ben Crowell that fixes incorrect behaviour of GD::Simple->fontMetrics
         * fix cross-compilation if gdlib.pc has no cflags by Fabrice Fontaine
@@ -158,7 +158,7 @@
 2.18	This version needs libgd 2.0.28 or higher.
 	Fixed documentation bug in synopsis of GD::Simple.
 	Updated Polyline to version 0.20
-2.17	Added animated GIF patches from Jaakko Hyv‰tti.
+2.17	Added animated GIF patches from Jaakko Hyv√§tti.
 	Added dynamic bitmapped font loading support.
 	Added fontconfig support.
 	Added a simplified API called GD::Simple.

--- a/GD.xs
+++ b/GD.xs
@@ -695,6 +695,7 @@ gdnewFromXpm(packname="GD::Image", filename)
         }
         RETVAL = img;
 #else
+	PERL_UNUSED_ARG(filename);
         errormsg = perl_get_sv("@",0);
         sv_setpv(errormsg,"libgd was not built with xpm support\n");
         XSRETURN_EMPTY;
@@ -963,6 +964,9 @@ gdgifanimbegin(image,globalcm=-1,loops=-1)
     RETVAL = newSVpvn((char*) data,size);
     gdFree(data);
 #else
+    PERL_UNUSED_ARG(image);
+    PERL_UNUSED_ARG(globalcm);
+    PERL_UNUSED_ARG(loops);
     die("libgd 2.0.33 or higher required for animated GIF support");
 #endif
   OUTPUT:
@@ -990,6 +994,13 @@ gdgifanimadd(image,localcm=-1,leftofs=-1,topofs=-1,delay=-1,disposal=-1,previm=0
     RETVAL = newSVpvn((char*) data,size);
     gdFree(data);
 #else
+    PERL_UNUSED_ARG(image);
+    PERL_UNUSED_ARG(localcm);
+    PERL_UNUSED_ARG(leftofs);
+    PERL_UNUSED_ARG(topofs);
+    PERL_UNUSED_ARG(delay);
+    PERL_UNUSED_ARG(disposal);
+    PERL_UNUSED_ARG(previm);
     die("libgd 2.0.33 or higher required for animated GIF support");
 #endif
   OUTPUT:
@@ -1535,6 +1546,15 @@ gdcopyRotated(dst,src,dstX,dstY,srcX,srcY,srcW,srcH,angle)
 #ifdef VERSION_33
         gdImageCopyRotated(dst,src,dstX,dstY,srcX,srcY,srcW,srcH,angle);
 #else
+        PERL_UNUSED_ARG(dst);
+        PERL_UNUSED_ARG(src);
+        PERL_UNUSED_ARG(dstX);
+        PERL_UNUSED_ARG(dstY);
+        PERL_UNUSED_ARG(srcX);
+        PERL_UNUSED_ARG(srcY);
+        PERL_UNUSED_ARG(srcW);
+        PERL_UNUSED_ARG(srcH);
+        PERL_UNUSED_ARG(angle);
         die("libgd 2.0.33 or higher required for copyRotated support");
 #endif
     }
@@ -2316,11 +2336,35 @@ gdstringFTCircle(image,cx,cy,radius,textRadius,fillPortion,fontname,points,top,b
             RETVAL = 1;
 	  }
 #else
+        /* if we have FT but not FTCIRCLE, this is all that's compiled */
+        PERL_UNUSED_ARG(image);
+        PERL_UNUSED_ARG(cx);
+        PERL_UNUSED_ARG(cy);
+        PERL_UNUSED_ARG(radius);
+        PERL_UNUSED_ARG(textRadius);
+        PERL_UNUSED_ARG(fillPortion);
+        PERL_UNUSED_ARG(fontname);
+        PERL_UNUSED_ARG(points);
+        PERL_UNUSED_ARG(top);
+        PERL_UNUSED_ARG(bottom);
+        PERL_UNUSED_ARG(fgcolor);
   	errormsg = perl_get_sv("@",0);
 	sv_setpv(errormsg,"libgd must be version 2.0.33 or higher to use this function\n");
 	XSRETURN_EMPTY;
 #endif
 #else
+        /* if we don't have FT, this is all that's compiled */
+        PERL_UNUSED_ARG(image);
+        PERL_UNUSED_ARG(cx);
+        PERL_UNUSED_ARG(cy);
+        PERL_UNUSED_ARG(radius);
+        PERL_UNUSED_ARG(textRadius);
+        PERL_UNUSED_ARG(fillPortion);
+        PERL_UNUSED_ARG(fontname);
+        PERL_UNUSED_ARG(points);
+        PERL_UNUSED_ARG(top);
+        PERL_UNUSED_ARG(bottom);
+        PERL_UNUSED_ARG(fgcolor);
   	errormsg = perl_get_sv("@",0);
 	sv_setpv(errormsg,"libgd was not built with FreeType support\n");
 	XSRETURN_EMPTY;
@@ -2336,12 +2380,12 @@ gduseFontConfig(image,flag)
   PROTOTYPE: $$
   CODE:
   {
-#ifdef HAVE_FONTCONFIG
     PERL_UNUSED_ARG(image);
+#ifdef HAVE_FONTCONFIG
     RETVAL = gdFTUseFontConfig(flag);
 #else
     SV* errormsg;
-    PERL_UNUSED_ARG(image);
+    PERL_UNUSED_ARG(flag);
     errormsg = perl_get_sv("@",0);
     sv_setpv(errormsg,"libgd was not built with fontconfig support\n");
     XSRETURN_EMPTY;


### PR DESCRIPTION
I added code (PERL_UNUSED_ARG() macro calls) anywhere that it appears that due to #ifdef and #ifndef the resulting code might not use one or more explicitly given arguments. This appears to cure the useFontConfig() error reported in RT 141125, and the additional newFromXpm() error (same sort of problem). The first (gcc) compile in the make test step now is clean, although the link (ld) step still fails (is running non-Verbose, unlike the lstein attempt). Still, it appears to be an improvement, so I'm submitting a PR. 

You should of course carefully look at the Action logs for PhilterPaper/Perl-GD to make sure nothing has broken in the process, and you're happy with the update. The link failure (also seen in February on lstein) looks like a bunch of stuff wasn't found. PhilterPaper/Perl-PDF-Builder GH CI just says to "run" GD, but failed somewhere after the compile with unused variable error (see RT 141125). It was working until the latest GD release, so maybe that can give an idea of how the GH CI might be made to work.