### PR TITLE
make: Improve regex to match in gdlib.pc

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -730,18 +730,19 @@ sub try_to_autoconfigure {
         }
         close $F;
         warn "Using $pc: $private\n";
+        # no trailing \b for freetype, also matches freetype2
         $features = 'GD_GIF GD_OPENPOLYGON';
-        $features .= ' GD_ZLIB' if $private =~ / zlib /;
-        $features .= ' GD_PNG' if $private =~ / libpng /;
-        $features .= ' GD_FREETYPE' if $private =~ / freetype/;
-        $features .= ' GD_FONTCONFIG' if $private =~ / fontconfig/;
-        $features .= ' GD_RAQM' if $private =~ / raqm/;
-        $features .= ' GD_JPEG' if $private =~ / libjpeg/;
-        $features .= ' GD_XPM' if $private =~ / xpm/;
-        $features .= ' GD_TIFF' if $private =~ / libtiff/;
-        $features .= ' GD_WEBP' if $private =~ / libwebp/;
-        $features .= ' GD_HEIF' if $private =~ / libheif/;
-        $features .= ' GD_AVIF' if $private =~ / libavif/;
+        $features .= ' GD_ZLIB' if $private =~ /\bzlib\b/;
+        $features .= ' GD_PNG' if $private =~ /\blibpng\b/;
+        $features .= ' GD_FREETYPE' if $private =~ /\bfreetype/;
+        $features .= ' GD_FONTCONFIG' if $private =~ /\bfontconfig/;
+        $features .= ' GD_RAQM' if $private =~ /\braqm/;
+        $features .= ' GD_JPEG' if $private =~ /\blibjpeg/;
+        $features .= ' GD_XPM' if $private =~ /\bxpm/;
+        $features .= ' GD_TIFF' if $private =~ /\blibtiff/;
+        $features .= ' GD_WEBP' if $private =~ /\blibwebp/;
+        $features .= ' GD_HEIF' if $private =~ /\blibheif/;
+        $features .= ' GD_AVIF' if $private =~ /\blibavif/;
       } else {
         warn "gdlib.pc not found, guessing the features.\n";
         $features = 'GD_GIF GD_OPENPOLYGON GD_ZLIB GD_PNG GD_FREETYPE GD_FONTCONFIG GD_JPEG GD_XPM GD_TIFF GD_WEBP';


### PR DESCRIPTION
In OpenBSD the gdlib.pc requires line is comma separated: Requires.private: freetype2, zlib, libpng, libjpeg, libtiff-4, fontconfig Then the spaces in the Makefile.PL do not match.  Replace them with \b.  As some library names may have a digit appended, do not introduce additional trailing \b.