### PR TITLE
test: Not has higher precedence than image compare bitwise and

### DIFF
--- a/t/GD.t
+++ b/t/GD.t
@@ -90,7 +90,7 @@ sub compare_image {
     $op = 'WBMP' if $suffix eq 'wbmp';
     my $method = "newFrom${op}";
     my $data2 = eval {GD::Image->$method($file)} or die $@;
-    return ! $data1->compare($data2) & GD_CMP_IMAGE();
+    return ! ($data1->compare($data2) & GD_CMP_IMAGE());
 }
 
 sub test1 {
@@ -278,18 +278,7 @@ sub run_image_regression_tests {
 	if (!$gd) {
 	    fail("unable to generate comparison image for test $t with $suffix: $@");
 	} else {
-            my $ok = compare($gd,$t,$suffix);
-            unless ($ok) {
-                if (($suffix ne 'gd2') or ($t == 7)) {
-                    ok(1, "TODO image comparison test $t $suffix failed (regen with --write)");
-                } else {
-                    ok($ok, "image comparison test $t $suffix");
-                }
-                diag("gd: ",GD::VERSION_STRING(),
-                     ", files: ",join(" ",glob("$images/t${t}/*.$suffix")));
-            } else {
-                ok($ok, "image comparison test $t $suffix");
-            }
+	    ok(compare($gd,$t,$suffix), "image comparison test $t $suffix");
 	}
     }
 }
@@ -304,10 +293,10 @@ sub run_round_trip_test {
     if (GD::Image->can("newFromGd") and GD::Image->can("newFromGd2")) {
         my $gd = $image->gd;
         my $image2 = GD::Image->newFromGdData($gd);
-        ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip gd');
+        ok(! ($image->compare($image2) & GD_CMP_IMAGE()),'round trip gd');
         my $gd2 = $image->gd2;
         $image2 = GD::Image->newFromGd2Data($gd2);
-        ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip gd2');
+        ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip gd2');
     }
     elsif (GD::Image->can("newFromPng")) {
       SKIP: {
@@ -316,10 +305,10 @@ sub run_round_trip_test {
           # GD 2.3.2 disabled the old GD and GD2 formats by default
           my $png = $image->png;
           my $image2 = GD::Image->newFromPngData($png);
-          ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip png');
+          ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip png');
           my $gif = $image->gif;
           $image2 = GD::Image->newFromGifData($gif);
-          ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip gif');
+          ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip gif');
         }
     }
     else {
@@ -330,10 +319,10 @@ sub run_round_trip_test {
 
           my $img = $image->tiff;
           my $image2 = GD::Image->newFromTiffData($img);
-          ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip tiff');
+          ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip tiff');
           my $gif = $image->gif;
           $image2 = GD::Image->newFromGifData($gif);
-          ok(!$image->compare($image2) & GD_CMP_IMAGE(),'round trip gif');
+          ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip gif');
         }
     }
 }


### PR DESCRIPTION
The output of $image->compare() has to be ANDed with the GD_CMP_ constants.  As ! has higher precedence than &, the comparison in t/GD.t first converted the result to boolean and then checked the bits.  Add parentheses to make the test pass.  This also fixes the test cases that were marked with TODO.  Convert them to hard fails.