### PR TITLE
doc: Describe image compare AND operation correctly

### DIFF
--- a/lib/GD.pm
+++ b/lib/GD.pm
@@ -1805,7 +1805,7 @@ is true color or not.
 =item B<$flag = $image1-E<gt>compare($image2)>
 
 Compare two images and return a bitmap describing the differences
-found, if any.  The return value must be logically AND'ed with one or
+found, if any.  The return value must be bitwise AND'ed with one or
 more constants in order to determine the differences.  The following
 constants are available:
 


### PR DESCRIPTION
The constants GD_CMP_ describe bit fields, the result of $image->compare() has to be ANDed bitwise.  This is what the example with & explains. perlop calls the & operator bitwise AND, so perldoc GD should also call this bitwise instead of logically.  Logical AND is &&.