### PR TITLE
test: newFromTiffData should use truecolor

### DIFF
--- a/t/GD.t
+++ b/t/GD.t
@@ -318,7 +318,7 @@ sub run_round_trip_test {
               and defined &GD::Image::newFromTiff;
 
           my $img = $image->tiff;
-          my $image2 = GD::Image->newFromTiffData($img);
+          my $image2 = GD::Image->newFromTiffData($img,1);
           ok(!($image->compare($image2) & GD_CMP_IMAGE()),'round trip tiff');
           my $gif = $image->gif;
           $image2 = GD::Image->newFromGifData($gif);


### PR DESCRIPTION
On a libgd built without libimagequant, the quantizer changes the colors slightly.  Requesting truecolor from GD::Image->newFromTiffData() skips the quantization and returns a lossless result.